### PR TITLE
only trigger codeql scans on pull_request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 name: "CodeQL analysis"
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This change will fix [workflow runs like this one](https://github.com/3rd-party-integrations/github-team-sync/actions/runs/5018189898/job/13592899783?pr=167).

`
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
`