### PR TITLE
fixing the variable scope issue with group_prefix

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,6 +256,7 @@ def load_custom_map(file="syncmap.yml"):
     """
     syncmap = {}
     ignore_users = []
+    group_prefix = []
     if os.path.isfile(file):
         from yaml import load, Loader
 


### PR DESCRIPTION
observed the following error when trying to run the latest release: `UnboundLocalError: local variable 'group_prefix' referenced before assignment`

Assigning the `group_prefix` outside the if statement scopes the variable correctly.